### PR TITLE
Add AttributeError to except ImportError statements

### DIFF
--- a/dissect/btrfs/btrfs.py
+++ b/dissect/btrfs/btrfs.py
@@ -17,7 +17,7 @@ from dissect.util.stream import BufferedStream
 
 try:
     from google_crc32c import extend as crc32c
-except ImportError:
+except (AttributeError, ImportError):
     from dissect.btrfs.crc32c import update as crc32c
 
 from dissect.btrfs.c_btrfs import FT_MAP, c_btrfs

--- a/dissect/btrfs/stream.py
+++ b/dissect/btrfs/stream.py
@@ -10,14 +10,14 @@ from dissect.util.stream import AlignedStream
 
 try:
     import lzo
-except ImportError:
+except (AttributeError, ImportError):
     from dissect.util.compression import lzo
 
 try:
     import zstandard
 
     HAS_ZSTD = True
-except ImportError:
+except (AttributeError, ImportError):
     HAS_ZSTD = False
 
 from dissect.btrfs.c_btrfs import (


### PR DESCRIPTION
In some cases windows throws an AttributeError instead of an ImportError during an import