### PR TITLE
Remove crc32c dependency

### DIFF
--- a/dissect/btrfs/btrfs.py
+++ b/dissect/btrfs/btrfs.py
@@ -12,17 +12,8 @@ from typing import TYPE_CHECKING, BinaryIO
 from uuid import UUID
 
 from dissect.util import ts
+from dissect.util.hash import crc32c
 from dissect.util.stream import BufferedStream
-
-try:
-    import warnings
-
-    # If the C extension is not available, google-crc32c will display a warning
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        from google_crc32c import extend as crc32c
-except ImportError:
-    from dissect.util.hash.crc32c import update as crc32c
 
 from dissect.btrfs.c_btrfs import FT_MAP, c_btrfs
 from dissect.btrfs.exceptions import (
@@ -272,7 +263,7 @@ class Subvolume:
             # Btrfs uses an initial CRC of `(u32)~1`, which is effectively the same as 1 XOR 0xFFFFFFFF
             # We still need to invert the XOR of the result though
             # https://stackoverflow.com/a/40433980
-            part_hash = (crc32c(1, part) ^ 0xFFFFFFFF) & 0xFFFFFFFF
+            part_hash = (crc32c.update(1, part) ^ 0xFFFFFFFF) & 0xFFFFFFFF
             try:
                 _, data = subvolume.tree.find(node.inum, c_btrfs.BTRFS_DIR_ITEM_KEY, part_hash)
             except KeyError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "dissect.cstruct>=4,<5",
-    "dissect.util>=3.22.dev,<4", #TODO: Remove once we release a new dissect version
+    "dissect.util>=3.23.dev,<4", #TODO: Remove once we release a new dissect version
 ]
 dynamic = ["version"]
 
@@ -39,13 +39,10 @@ repository = "https://github.com/fox-it/dissect.btrfs"
 full = [
     "zstandard",
 ]
-gcrc32 = [
-    "google-crc32c",
-]
 dev = [
     "dissect.btrfs[full]",
     "dissect.cstruct>=4.0.dev,<5.0.dev",
-    "dissect.util>=3.22.dev,<4.0.dev", #TODO: Remove once we release a new dissect version
+    "dissect.util>=3.23.dev,<4.0.dev", #TODO: Remove once we release a new dissect version
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Now that we have a Rust version in `dissect.util`.